### PR TITLE
Restrict max width setting to site icon control

### DIFF
--- a/css/customizer-resizer.css
+++ b/css/customizer-resizer.css
@@ -182,7 +182,7 @@
 	margin-top: 6px;
 }
 
-#customize-controls img {
+#customize-controls .customize-control-site_icon img {
 	display: block;
 	max-width: 256px;
 	margin: 0 auto;


### PR DESCRIPTION
When restricting the max size of the site icon, you used a CSS rule that will effect every image in the customizer pane. Would you consider this change to the rule which will narrow the scope to which it's applied?

This will prevent third parties from having to write a lot of explicit rules to overrule this one.
